### PR TITLE
Catch error on join

### DIFF
--- a/lib/phoenix_channel_client.ex
+++ b/lib/phoenix_channel_client.ex
@@ -211,17 +211,21 @@ defmodule PhoenixChannelClient do
       end
       mapper = fn %{payload: payload} -> payload end
       subscribe(channel.socket.server_name, subscription, matcher, mapper)
-      do_push(channel, event, payload, ref)
-      receive do
-        payload ->
-          case payload do
-            %{"status" => "ok", "response" => response} ->
-              {:ok, response}
-            %{"status" => "error", "response" => response} ->
-              {:error, response}
-          end
-      after
-        timeout -> :timeout
+      try do
+        do_push(channel, event, payload, ref)
+        receive do
+          payload ->
+            case payload do
+              %{"status" => "ok", "response" => response} ->
+                {:ok, response}
+              %{"status" => "error", "response" => response} ->
+                {:error, response}
+            end
+        after
+          timeout -> :timeout
+        end
+      rescue
+        e -> {:error, e}
       end
     end)
     try do


### PR DESCRIPTION
when an error occurs this goes unnoticed. instead it will send an exit
message to the linked process