### PR TITLE
Implement the heartbeat to keep the websocket connection alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Add `{:phoenixchannelclient, "~> 0.1.0"}` to deps.
   host: "localhost",
   path: "/socket/websocket",
   params: %{token: "something"},
-  secure: false)
+  secure: false,
+  heartbeat_interval: 30_000)
 
 channel = PhoenixChannelClient.channel(socket, "room:public", %{name: "Ryo"})
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhoenixChannelClient.Mixfile do
     [app: :phoenixchannelclient,
      description: "Phoenix Channel Client",
      package: package(),
-     version: "0.1.2",
+     version: "0.1.3",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test_server/web/channels/user_socket.ex
+++ b/test_server/web/channels/user_socket.ex
@@ -2,7 +2,8 @@ defmodule TestServer.UserSocket do
   use Phoenix.Socket
 
   channel "*", TestServer.UserChannel
-  transport :websocket, Phoenix.Transports.WebSocket
+  transport :websocket, Phoenix.Transports.WebSocket,
+    timeout: 1_000
 
   def connect(params, socket) do
     if params["authenticated"] === "true" do


### PR DESCRIPTION
I've just realized that the socket gets closed by the server after 60 seconds cause the heartbeat was not implemented. 

